### PR TITLE
Use scoped lifecycle for HotKeys service

### DIFF
--- a/Toolbelt.Blazor.HotKeys/HotKeysExtensions.cs
+++ b/Toolbelt.Blazor.HotKeys/HotKeysExtensions.cs
@@ -14,7 +14,7 @@ namespace Toolbelt.Blazor.Extensions.DependencyInjection
         /// <param name="services">The Microsoft.Extensions.DependencyInjection.IServiceCollection to add the service to.</param>
         public static IServiceCollection AddHotKeys(this IServiceCollection services)
         {
-            services.AddSingleton(serviceProvider => new global::Toolbelt.Blazor.HotKeys.HotKeys(serviceProvider.GetService<IJSRuntime>()));
+            services.AddScoped(serviceProvider => new global::Toolbelt.Blazor.HotKeys.HotKeys(serviceProvider.GetService<IJSRuntime>()));
             return services;
         }
     }


### PR DESCRIPTION
Thanks for this library, I just tried it out and it works brilliantly 🙂

With one exception - the `IJSRuntime` service is registered as a scoped service, so the `HotKeys` service needs to be registered as scoped too. I'm using the release version of Blazor, 3.2.0 - without this change you get a lifecycle exception when you inject the `HotKeys`.